### PR TITLE
 Move is-invalid class to the input

### DIFF
--- a/src/BootstrapForm.php
+++ b/src/BootstrapForm.php
@@ -813,7 +813,7 @@ class BootstrapForm
      */
     protected function getFormGroupOptions($name = null, array $options = [])
     {
-        $class = 'form-group row';
+        $class = 'form-group';
 
         if ($name) {
             $class .= ' ' . $this->getFieldErrorClass($name);
@@ -1031,7 +1031,7 @@ class BootstrapForm
      * @param  string  $format
      * @return mixed
      */
-    protected function getFieldError($field, $format = '<span class="help-block">:message</span>')
+    protected function getFieldError($field, $format = '<span class="invalid-feedback">:message</span>')
     {
         $field = $this->flattenFieldName($field);
 
@@ -1056,7 +1056,7 @@ class BootstrapForm
      * @param  string  $class
      * @return string
      */
-    protected function getFieldErrorClass($field, $class = 'has-error')
+    protected function getFieldErrorClass($field, $class = 'is-invalid')
     {
         return $this->getFieldError($field) ? $class : null;
     }

--- a/src/BootstrapForm.php
+++ b/src/BootstrapForm.php
@@ -14,7 +14,7 @@ use Illuminate\Support\Traits\Macroable;
 class BootstrapForm
 {
     use Macroable;
-    
+
     /**
      * Illuminate HtmlBuilder instance.
      *
@@ -813,13 +813,7 @@ class BootstrapForm
      */
     protected function getFormGroupOptions($name = null, array $options = [])
     {
-        $class = 'form-group';
-
-        if ($name) {
-            $class .= ' ' . $this->getFieldErrorClass($name);
-        }
-
-        return array_merge(['class' => $class], $options);
+        return array_merge(['class' => 'form-group'], $options);
     }
 
     /**
@@ -832,7 +826,11 @@ class BootstrapForm
      */
     protected function getFieldOptions(array $options = [], $name = null)
     {
-        $options['class'] = trim('form-control ' . $this->getFieldOptionsClass($options));
+        $options['class'] = trim(implode(' ', [
+                'form-control',
+                $this->getFieldOptionsClass($options),
+                $this->getFieldErrorClass($name),
+        ]));
 
         // If we've been provided the input name and the ID has not been set in the options,
         // we'll use the name as the ID to hook it up with the label.

--- a/src/BootstrapForm.php
+++ b/src/BootstrapForm.php
@@ -972,7 +972,7 @@ class BootstrapForm
      */
     public function getIconPrefix()
     {
-        return $this->iconPrefix ?: $this->config->get('bootstrap_form.icon_prefix', 'fa fa-');
+        return $this->iconPrefix ?: $this->config->get('bootstrap_form.icon_prefix', ' ');
     }
 
     /**

--- a/src/BootstrapForm.php
+++ b/src/BootstrapForm.php
@@ -698,7 +698,7 @@ class BootstrapForm
     {
         $prefix = array_get($options, 'prefix', $this->getIconPrefix());
 
-        return '<div class="input-group-addon"><span ' . $this->html->attributes($options) . '><i class="'.$prefix.$icon.'"></i></span></div>';
+        return '<div class="input-group-prepend"><span class="input-group-text"' . $this->html->attributes($options) . '><i class="'.$prefix.$icon.'"></i></span></div>';
     }
 
     /**

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -52,5 +52,5 @@ return [
     |
     */
 
-    'icon_prefix' => 'fa fa-'
+    'icon_prefix' => ''
 ];


### PR DESCRIPTION
Moved the is-invalid class to the input as this is where it should be in the release of Boostrap 4.

See https://getbootstrap.com/docs/4.0/components/forms/#server-side

Looks like the master branch is out of date compared to the last tag.